### PR TITLE
Fix hermes spacing reference error

### DIFF
--- a/theme/index.ts
+++ b/theme/index.ts
@@ -13,6 +13,16 @@ export const colors = {
 };
 
 export const spacing = {
+  // Numeric aliases for backwards compatibility with code using spacing[1..8]
+  1: tokens.spacing[1],
+  2: tokens.spacing[2],
+  3: tokens.spacing[3],
+  4: tokens.spacing[4],
+  5: tokens.spacing[5],
+  6: tokens.spacing[6],
+  7: tokens.spacing[7],
+  8: tokens.spacing[8],
+  // Named scale
   xs: tokens.spacing[1],
   sm: tokens.spacing[2],
   md: tokens.spacing[4],


### PR DESCRIPTION
Add numeric aliases to `theme.spacing` to resolve Hermes `ReferenceError` when using bracket notation.

The Hermes runtime was throwing a `ReferenceError` because `theme.spacing` only defined named keys (e.g., `spacing.md`). When code attempted to access `spacing` using numeric bracket notation (e.g., `spacing[4]`), Hermes failed to find the property. This change adds numeric aliases to `theme.spacing` to ensure both named and numeric access patterns are supported, preventing these runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebb27700-cc70-4919-8acb-7722d9a0284b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebb27700-cc70-4919-8acb-7722d9a0284b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

