### PR TITLE
Fix hermes spacing reference error

### DIFF
--- a/screens/RunStatsScreen.tsx
+++ b/screens/RunStatsScreen.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import { View, Text, ScrollView, StyleSheet, Dimensions } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useRoute } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RouteProp } from '@react-navigation/native';
-import type { TimelineStackParamList } from '../types/navigation';
-import { colors, spacing, borderRadius, typography } from '../theme';``
-import { Avatar } from '../components/Avatar';
-import { formatDistance, formatPace, formatTime, getRelativeTime } from '../utils/format';
-import { useStore } from '../state/store';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React from 'react';
+import { Dimensions, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MapView, { Polyline, PROVIDER_DEFAULT } from 'react-native-maps';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Avatar } from '../components/Avatar';
+import { useStore } from '../state/store';
+import { borderRadius, colors, spacing, typography } from '../theme';
+import type { TimelineStackParamList } from '../types/navigation';
+import { formatDistance, formatPace, getRelativeTime } from '../utils/format';
 import { decodePolyline, regionForCoordinates } from '../utils/geo';
 
 

--- a/screens/SettingsScreen.tsx
+++ b/screens/SettingsScreen.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Pressable } from 'react-native';
+import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { colors } from '../theme';
 import { useStore } from '../state/store';
+import { borderRadius, colors, spacing, typography } from '../theme';
 
 export const SettingsScreen: React.FC = () => {
   const signOut = useStore(state => state.signOut);


### PR DESCRIPTION
Fix Hermes `ReferenceError: Property 'spacing' doesn't exist` by adding missing theme imports and removing stray backticks.

---
<a href="https://cursor.com/background-agent?bcId=bc-7845d226-ff25-46f7-9963-69537efc519a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7845d226-ff25-46f7-9963-69537efc519a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

